### PR TITLE
Dragon AoE partials, lifetap partials, skill type 52 fix

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -141,7 +141,7 @@ bool IsDamageSpell(uint16 spellid)
 	for (int o = 0; o < EFFECT_COUNT; o++) {
 		uint32 tid = spells[spellid].effectid[o];
 		if ((tid == SE_CurrentHPOnce || tid == SE_CurrentHP) &&
-				spells[spellid].targettype != ST_Tap && spells[spellid].buffduration < 1 &&
+				spells[spellid].buffduration < 1 &&
 				spells[spellid].base[o] < 0)
 			return true;
 	}
@@ -417,10 +417,21 @@ bool IsPartialCapableSpell(uint16 spell_id)
 	if (spells[spell_id].no_partial_resist)
 		return false;
 	
-	if (IsPureNukeSpell(spell_id))
-		return true;
+	// return false if any spell includes an effect that isn't direct damage or dispel
+	// dragon AoEs have dispels but are partially resistable
+	for (int o = 0; o < EFFECT_COUNT; o++)
+	{
+		uint16 tid = spells[spell_id].effectid[o];
 
-	return false;
+		if (IsBlankSpellEffect(spell_id, o) || tid == SE_CancelMagic)
+			continue;
+
+		if ((tid != SE_CurrentHPOnce && tid != SE_CurrentHP )
+			|| spells[spell_id].buffduration > 0 || spells[spell_id].base[o] >= 0)
+			return false;
+	}
+
+	return true;
 }
 
 bool IsResistableSpell(uint16 spell_id)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3481,6 +3481,15 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 
 	//send damage packet...
 	if(!iBuffTic) { //buff ticks do not send damage, instead they just call SendHPUpdate(), which is done below
+
+		// hundreds of spells have the skill id set to tiger claw in the spell data
+		// without this, lots of stuff will 'strike' instead of give a proper spell damage message
+		uint8 skill_id = skill_used;
+		if (skill_used == SkillTigerClaw && spell_id > 0)
+		{
+			skill_id = SkillEvocation;
+		}
+
 		EQApplicationPacket* outapp = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
 		CombatDamage_Struct* a = (CombatDamage_Struct*)outapp->pBuffer;
 		a->target = GetID();
@@ -3490,10 +3499,10 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 			a->source = 0;
 		else
 			a->source = attacker->GetID();
-		a->type = SkillDamageTypes[skill_used]; // was 0x1c
+		a->type = SkillDamageTypes[skill_id]; // was 0x1c
 		a->damage = damage;
 		a->spellid = spell_id;
-
+		
 		//Note: if players can become pets, they will not receive damage messages of their own
 		//this was done to simplify the code here (since we can only effectively skip one mob on queue)
 		eqFilterType filter;


### PR DESCRIPTION
Direct damage spells with a dispel component will now partial hit. (i.e. dragon aoes)
Lifetap spells will now partial hit.
Damaging spells with skill type 52 (tiger claw) will now send skill type 24 (evocation) in the packet.
NPCs will no longer stop casting offensive spells when their mana is below 10%, but will only cast spells they have the mana for.
